### PR TITLE
Julia v1.0 fixes.

### DIFF
--- a/Examples/Bones1/jbones1.jl
+++ b/Examples/Bones1/jbones1.jl
@@ -144,7 +144,7 @@ cd(ProjDir) do
   ## Plotting
   p = plot(sim, [:trace, :mean, :density, :autocor], legend=true);
   draw(p, ncol=4, filename="$(jagsmodel.name)-summaryplot", fmt=:svg)
-  draw(p, ncol=4, filename="$(jagsmodel.name)-summaryplot", fmt=:pdf)
+  # draw(p, ncol=4, filename="$(jagsmodel.name)-summaryplot", fmt=:pdf)
 
   # Below will only work on OSX, please adjust for your environment.
   # JULIA_SVG_BROWSER is set from environment variable JULIA_SVG_BROWSER

--- a/Examples/Bones2/jbones2.jl
+++ b/Examples/Bones2/jbones2.jl
@@ -46,16 +46,16 @@ cd(ProjDir) do
     NaN, NaN, NaN, 17.4944, 2.3016, 2.497, 2.3689, 3.9525, 8.2832, 7.1053, 
     NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, 
     NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, 3.2535, 3.2306, 
-    2.9495, 5.3198, 10.4988, 10.3038;], 34, 4)
+    2.9495, 5.3198, 10.4988, 10.3038], 34, 4)
   data["delta"] = [
     2.9541, 0.6603, 0.7965, 1.0495, 5.7874, 3.8376, 0.6324, 0.8272, 
     0.6968, 0.8747, 0.8136, 0.8246, 0.6711, 0.978, 1.1528, 1.6923, 
     1.0331, 0.5381, 1.0688, 8.1123, 0.9974, 1.2656, 1.1802, 1.368, 
     1.5435, 1.5006, 1.6766, 1.4297, 3.385, 3.3085, 3.4007, 2.0906, 
-    1.0954, 1.5329;]
+    1.0954, 1.5329]
   data["ncat"] = [
     2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 
-    3, 3, 3, 3, 3, 3, 3, 4, 5, 5, 5, 5, 5, 5;]
+    3, 3, 3, 3, 3, 3, 3, 4, 5, 5, 5, 5, 5, 5]
   data["grade"] = reshape([
     1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 
     1, 1, 1, 1, 1, 1, 1, 2, 2, 1, 1, 1, 1, 1, 1, 1, 2, 1, 2, NaN, 
@@ -78,7 +78,7 @@ cd(ProjDir) do
     2, 4, 2, 3, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 1, 1, 3, 5, 5, 5, 
     5, 5, 5, 5, 5, 5, 5, 1, 1, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 2, 
     2, 3, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 1, 1, 1, 1, 2, 3, 3, 3, 4, 
-    5, 5, 5, 5, 1, 1, 1, 1, 3, 3, 3, 4, 4, 5, 5, 5, 5;], 13, 34)
+    5, 5, 5, 5, 1, 1, 1, 1, 3, 3, 3, 4, 4, 5, 5, 5, 5], 13, 34)
 
   grade = reshape([
         NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, 
@@ -108,7 +108,7 @@ cd(ProjDir) do
         NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, 
         NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, 
         NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, 
-        NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN;], 13, 34)
+        NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN], 13, 34)
       
   inits = [
     Dict("theta"     => [0.5, 1, 2, 3, 5, 6, 7, 8, 9, 12, 13, 16, 18],
@@ -155,7 +155,7 @@ cd(ProjDir) do
   ## Plotting
   p = plot(sim, [:trace, :mean, :density, :autocor], legend=true);
   draw(p, ncol=4, filename="$(jagsmodel.name)-summaryplot", fmt=:svg)
-  draw(p, ncol=4, filename="$(jagsmodel.name)-summaryplot", fmt=:pdf)
+  # draw(p, ncol=4, filename="$(jagsmodel.name)-summaryplot", fmt=:pdf)
 
   # Below will only work on OSX, please adjust for your environment.
   # JULIA_SVG_BROWSER is set from environment variable JULIA_SVG_BROWSER

--- a/Examples/Dyes/jdyes.jl
+++ b/Examples/Dyes/jdyes.jl
@@ -70,7 +70,7 @@ cd(ProjDir) do
   ## Plotting
   p = plot(sim, [:trace, :mean, :density, :autocor], legend=true);
   draw(p, ncol=4, filename="$(jagsmodel.name)-summaryplot", fmt=:svg)
-  draw(p, ncol=4, filename="$(jagsmodel.name)-summaryplot", fmt=:pdf)
+  # draw(p, ncol=4, filename="$(jagsmodel.name)-summaryplot", fmt=:pdf)
 
   # Below will only work on OSX, please adjust for your environment.
   # JULIA_SVG_BROWSER is set from environment variable JULIA_SVG_BROWSER

--- a/Examples/Line1/jline1.jl
+++ b/Examples/Line1/jline1.jl
@@ -86,7 +86,7 @@ cd(ProjDir) do
   ## Plotting
   p = plot(sim, [:trace, :mean, :density, :autocor], legend=true);
   draw(p, nrow=4, ncol=4, filename="$(jagsmodel.name)-summaryplot", fmt=:svg)
-  draw(p, nrow=4, ncol=4, filename="$(jagsmodel.name)-summaryplot", fmt=:pdf)
+  # draw(p, nrow=4, ncol=4, filename="$(jagsmodel.name)-summaryplot", fmt=:pdf)# Requires Cairo
 
   # Below will only work on OSX, please adjust for your environment.
   # JULIA_SVG_BROWSER is set from environment variable JULIA_SVG_BROWSER

--- a/Examples/Line2/jline2.jl
+++ b/Examples/Line2/jline2.jl
@@ -88,7 +88,7 @@ cd(ProjDir) do
   ## Plotting
   p = plot(sim, [:trace, :mean, :density, :autocor], legend=true);
   draw(p, nrow=4, ncol=4, filename="$(jagsmodel.name)-summaryplot", fmt=:svg)
-  draw(p, nrow=4, ncol=4, filename="$(jagsmodel.name)-summaryplot", fmt=:pdf)
+  # draw(p, nrow=4, ncol=4, filename="$(jagsmodel.name)-summaryplot", fmt=:pdf)
 
   # Below will only work on OSX, please adjust for your environment.
   # JULIA_SVG_BROWSER is set from environment variable JULIA_SVG_BROWSER

--- a/Examples/Line3/jline3.jl
+++ b/Examples/Line3/jline3.jl
@@ -87,7 +87,7 @@ cd(ProjDir) do
   ## Plotting
   p = plot(sim, [:trace, :mean, :density, :autocor], legend=true);
   draw(p, nrow=4, ncol=4, filename="$(jagsmodel.name)-summaryplot", fmt=:svg)
-  draw(p, nrow=4, ncol=4, filename="$(jagsmodel.name)-summaryplot", fmt=:pdf)
+  # draw(p, nrow=4, ncol=4, filename="$(jagsmodel.name)-summaryplot", fmt=:pdf)
 
   # Below will only work on OSX, please adjust for your environment.
   # JULIA_SVG_BROWSER is set from environment variable JULIA_SVG_BROWSER

--- a/Examples/Line4/jline4.jl
+++ b/Examples/Line4/jline4.jl
@@ -87,7 +87,7 @@ cd(ProjDir) do
   ## Plotting
   p = plot(sim, [:trace, :mean, :density, :autocor], legend=true);
   draw(p, nrow=4, ncol=4, filename="$(jagsmodel.name)-summaryplot", fmt=:svg)
-  draw(p, nrow=4, ncol=4, filename="$(jagsmodel.name)-summaryplot", fmt=:pdf)
+  # draw(p, nrow=4, ncol=4, filename="$(jagsmodel.name)-summaryplot", fmt=:pdf)
 
   # Below will only work on OSX, please adjust for your environment.
   # JULIA_SVG_BROWSER is set from environment variable JULIA_SVG_BROWSER

--- a/Examples/Rats/jrats.jl
+++ b/Examples/Rats/jrats.jl
@@ -104,7 +104,7 @@ cd(ProjDir) do
   ## Plotting
   p = plot(sim, [:trace, :mean, :density, :autocor], legend=true);
   draw(p, ncol=4, filename="$(jagsmodel.name)-summaryplot", fmt=:svg)
-  draw(p, ncol=4, filename="$(jagsmodel.name)-summaryplot", fmt=:pdf)
+  # draw(p, ncol=4, filename="$(jagsmodel.name)-summaryplot", fmt=:pdf)
 
   # Below will only work on OSX, please adjust for your environment.
   # JULIA_SVG_BROWSER is set from environment variable JULIA_SVG_BROWSER

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
-julia 0.6
-DataArrays
-Mamba 0.10.0
+julia 0.7
+Mamba 0.12

--- a/src/Jags.jl
+++ b/src/Jags.jl
@@ -1,6 +1,6 @@
 module Jags
 
-using Compat, Pkg, Documenter, DelimitedFiles, Unicode
+using Compat, Pkg, Documenter, DelimitedFiles, Unicode, Mamba
 
 #### Includes ####
 

--- a/src/jagsmodel.jl
+++ b/src/jagsmodel.jl
@@ -118,7 +118,7 @@ end
 function update_bugs_file(file::AbstractString, str::AbstractString)
   str2 = ""
   if isfile(file)
-    str2 = open(readstring, file, "r")
+    str2 = read(file)
     str != str2 && rm(file)
   end
   if str != str2
@@ -212,7 +212,7 @@ end
 function check_jags_file(file::String, str::String)
   str2 = ""
   if isfile(file)
-    str2 = open(readstring, file, "r")
+    str2 = read(file)
     str != str2 && rm(file)
   end
   if str != str2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ println("Running tests for Jags-j1.0.0-v2.0.0:")
 using Compat, Jags
 using Test
 
-code_tests = ["test_cmd.jl";]
+code_tests = ["test_cmd.jl"]
 
 println("Run execution_tests only if Jags is available")
 execution_tests = [


### PR DESCRIPTION
Some fixes for running Jags on v1.0. Passes all tests on v1.03 and v1.1.0rc1 on my system.

I commented out the pdf generation in the examples to avoid Cairo and Fontconfig dependency.